### PR TITLE
✨ Add method BuildClaimsPrincipalAsync

### DIFF
--- a/src/BitzArt.Blazor.Auth.Server/Services/ServerSidePrerenderAuthenticationStateProvider.cs
+++ b/src/BitzArt.Blazor.Auth.Server/Services/ServerSidePrerenderAuthenticationStateProvider.cs
@@ -26,7 +26,7 @@ internal class ServerSidePrerenderAuthenticationStateProvider(
         if (!string.IsNullOrWhiteSpace(accessToken))
         {
             logger.LogDebug("Access token was found in request cookies.");
-            var principal = claimsService.BuildClaimsPrincipal(accessToken);
+            var principal = await claimsService.BuildClaimsPrincipalAsync(accessToken);
             return new AuthenticationState(principal);
         }
 
@@ -47,7 +47,7 @@ internal class ServerSidePrerenderAuthenticationStateProvider(
             }
 
             logger.LogDebug("User's JWT pair was successfully refreshed.");
-            var principal = claimsService.BuildClaimsPrincipal(refreshResult.JwtPair!.AccessToken!);
+            var principal = await claimsService.BuildClaimsPrincipalAsync(refreshResult.JwtPair!.AccessToken!);
             
             httpContext.Response.Cookies.Append(Constants.AccessTokenCookieName, refreshResult.JwtPair!.AccessToken!, new CookieOptions
             {

--- a/src/BitzArt.Blazor.Auth/Interfaces/IIdentityClaimsService.cs
+++ b/src/BitzArt.Blazor.Auth/Interfaces/IIdentityClaimsService.cs
@@ -5,4 +5,5 @@ namespace BitzArt.Blazor.Auth;
 public interface IIdentityClaimsService
 {
     public ClaimsPrincipal BuildClaimsPrincipal(string accessToken);
+    public Task<ClaimsPrincipal> BuildClaimsPrincipalAsync(string accessToken);
 }

--- a/src/BitzArt.Blazor.Auth/Providers/BlazorAuthenticationStateProvider.cs
+++ b/src/BitzArt.Blazor.Auth/Providers/BlazorAuthenticationStateProvider.cs
@@ -51,7 +51,7 @@ public class BlazorAuthenticationStateProvider(
         if (accessTokenCookie is not null && !string.IsNullOrWhiteSpace(accessTokenCookie.Value))
         {
             _logger.LogDebug("Access token was found in cookies.");
-            var principal = ClaimsService.BuildClaimsPrincipal(accessTokenCookie.Value);
+            var principal = await ClaimsService.BuildClaimsPrincipalAsync(accessTokenCookie.Value);
             return Save(new AuthenticationState(principal));
         }
 
@@ -70,7 +70,7 @@ public class BlazorAuthenticationStateProvider(
             }
 
             _logger.LogDebug("User's JWT pair was successfully refreshed.");
-            var principal = ClaimsService.BuildClaimsPrincipal(refreshResult.JwtPair!.AccessToken!);
+            var principal = await ClaimsService.BuildClaimsPrincipalAsync(refreshResult.JwtPair!.AccessToken!);
             return Save(new AuthenticationState(principal));
         }
 

--- a/src/BitzArt.Blazor.Auth/Services/IdentityClaimsService.cs
+++ b/src/BitzArt.Blazor.Auth/Services/IdentityClaimsService.cs
@@ -22,6 +22,11 @@ public class IdentityClaimsService() : IIdentityClaimsService
         return new ClaimsPrincipal(new ClaimsIdentity(claims, "Custom"));
     }
 
+    public virtual Task<ClaimsPrincipal> BuildClaimsPrincipalAsync(string accessToken)
+    {
+        return Task.FromResult(BuildClaimsPrincipal(accessToken));
+    }
+
     protected virtual bool ValidateRawToken(string token) => true;
 
     protected virtual bool ValidateToken(JwtSecurityToken token) => true;


### PR DESCRIPTION
Adds an async version of the virtual method BuildClaimsPrincipal. By default the new async method calls the existing sync method.

The goal is to allow retrieving additional information from an endpoint, that should be included in the identity object, but should not be included in the cookie (due to the 4k cookie size limit).

For example, a very long list of groups that the user is member of.