### PR TITLE
`BlazorAuthenticationStateProvider.Save`: invoke `NotifyAuthenticationStateChanged`

### DIFF
--- a/src/BitzArt.Blazor.Auth/Providers/BlazorAuthenticationStateProvider.cs
+++ b/src/BitzArt.Blazor.Auth/Providers/BlazorAuthenticationStateProvider.cs
@@ -22,6 +22,7 @@ public class BlazorAuthenticationStateProvider(
     private AuthenticationState Save(AuthenticationState state)
     {
         _authenticationState = state;
+        NotifyAuthenticationStateChanged(Task.FromResult(state));
         return state;
     }
 


### PR DESCRIPTION
Blazor needs to be informed about authentication state changes.